### PR TITLE
Add 12.x support, change default node to 10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## nodejs
- 
+
 [![Build Status](https://travis-ci.org/Oefenweb/ansible-nodejs.svg?branch=master)](https://travis-ci.org/Oefenweb/ansible-nodejs) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-nodejs-blue.svg)](https://galaxy.ansible.com/Oefenweb/nodejs)
 
 Set up the latest version of [Node.js](https://nodejs.org) and [npm](https://www.npmjs.com) in Debian-like systems.
@@ -11,7 +11,7 @@ Set up the latest version of [Node.js](https://nodejs.org) and [npm](https://www
 
 #### Variables
 
-* `nodejs_version` [default: `nodejs-v6x`]: Version to install (e.g. `nodejs-v10x`, `nodejs-v9x`, `nodejs-v8x`, `nodejs-v7x`, `nodejs-v6x`, `nodejs-v5x`, `nodejs-v012`, `nodejs-v010`, `iojs-v3x`, `iojs-v2x`, `iojs-v1x`)
+* `nodejs_version` [default: `nodejs-v10x`]: Version to install (e.g. `nodejs-v12x`, `nodejs-v10x`, `nodejs-v8x`, `nodejs-v7x`, `nodejs-v6x`, `nodejs-v5x`, `nodejs-v012`, `nodejs-v010`, `iojs-v3x`, `iojs-v2x`, `iojs-v1x`)
 
 * `nodejs_install` [default: `[build-essential]`]: Packages to install
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # defaults file for nodejs
 ---
-nodejs_version: 'nodejs-v8x'
+nodejs_version: 'nodejs-v10x'
 
 nodejs_install:
   # To compile and install native addons from npm you may also need to install build tools

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 # vars file for nodejs
 ---
 nodejs_version_map:
+  nodejs-v12x: '12.x'
   nodejs-v10x: '10.x'
   nodejs-v9x: '9.x'
   nodejs-v8x: '8.x'


### PR DESCRIPTION
As every even version is a Nodejs "LTS" version (https://nodejs.org/en/about/releases/) I've added the 12.x 
Also changed the default to 10.x, as 8.x is out of support since January 2020.

(Not tested yet though, but **should** work, will come back tomorrow or monday after I've run with our deploy with the 12.x version)